### PR TITLE
ci: build container from Dockerfile in PR workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,8 +14,6 @@ concurrency:
 jobs:
   example:
     runs-on: ubuntu-latest
-    container:
-      image: semnil/tfdiagrams:0.5.1
 
     steps:
       - uses: actions/create-github-app-token@v3
@@ -29,19 +27,17 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - name: Add bash command (for ad-m/github-push-action)
-        if: ${{ success() }}
-        run: |
-          apk add bash
+      - name: Build container
+        run: docker build -t tfdiagrams-local .
       - name: Git config
         run: |
           git config --global user.name "github actions"
           git config --global user.email "1051877+semnil@users.noreply.github.com"
-          git config --global --add safe.directory /__w/tfdiagrams/tfdiagrams
 
       - name: Generate graph
         run: |
-          cd example/count && terraform init && terraform graph | tfdot -ograph.png
+          docker run --rm -v "${{ github.workspace }}:/app" -w /app tfdiagrams-local \
+            sh -c "cd example/count && terraform init && terraform graph | tfdot -ograph.png"
           git add -A
           git diff --cached --exit-code --quiet || echo "update=true" >> $GITHUB_OUTPUT
         id: graph_status


### PR DESCRIPTION
## Summary
- Remove hardcoded `semnil/tfdiagrams:0.5.1` container image from Example workflow
- Build the Docker image from the repo's Dockerfile during the workflow run
- PRs now test the actual Dockerfile instead of a stale pre-published image
- Remove unnecessary `apk add bash` and `safe.directory` workarounds

## Test plan
- [ ] Open a PR and verify the Example workflow builds and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)